### PR TITLE
feat: add support for http transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,22 @@ This repository is designed to be run as a [Model Context Protocol server](https
 
 Ensure you have completed the "Setup and Installation" steps, especially installing the project so the mcp-yelp-agent script is available.
 
-Configure your MCP client with the following JSON settings:
+#### **Server Configuration**
 
-```
+The server supports multiple transport protocols and can be configured with command-line arguments. While `stdio` is the primary transport for most MCP clients, other options are available for different use cases.
+
+*   `--transport`: Choose the communication protocol.
+    *   `stdio` (default): Standard input/output, ideal for local tools.
+    *   `streamable-http`: Streamable HTTP.
+    *   `sse`: Server-Sent Events.
+*   `--host`: The host address to bind to (e.g., `127.0.0.1` or `0.0.0.0`). Default is `127.0.0.1`.
+*   `--port`: The port to listen on. Default is `8000`.
+
+### **Method 1: Running without Docker**
+
+Configure your MCP client with the following JSON settings to run the server with the default `stdio` transport.
+
+```json
 {
   "mcpServers": {
     "yelp_agent": {
@@ -87,9 +100,9 @@ Configure your MCP client with the following JSON settings:
 
 Notes:
 
-* Replace \<PATH\_TO\_YOUR\_CLONED\_PROJECT\_DIRECTORY\> with the absolute path to where you cloned this project.
-* Replace \<YOUR\_YELP\_FUSION\_API\_KEY\> with your actual Yelp Fusion API key.
-* If your MCP client has trouble invoking uv directly, you might need to provide the full path to the uv binary. You can find this by running `which uv` in your terminal.
+*   Replace `<PATH_TO_YOUR_CLONED_PROJECT_DIRECTORY>` with the absolute path to where you cloned this project.
+*   Replace `<YOUR_YELP_FUSION_API_KEY>` with your actual Yelp Fusion API key.
+*   If your MCP client has trouble invoking uv directly, you might need to provide the full path to the uv binary. You can find this by running `which uv` in your terminal.
 
 ### **Method 2: Running with Docker**
 
@@ -97,7 +110,7 @@ Ensure you have built the Docker image as described in "Building the Docker Imag
 
 Configure your MCP client with the following JSON settings:
 
-```
+```json
 {
   "mcpServers": {
     "yelp_agent": {
@@ -117,5 +130,5 @@ Configure your MCP client with the following JSON settings:
 
 Notes:
 
-* Replace \<YOUR\_YELP\_FUSION\_API\_KEY\> with your actual Yelp Fusion API key.
-* If your MCP client has trouble invoking docker from the system PATH, you might need to provide the full path to its binary (e.g., run which docker).
+*   Replace `<YOUR_YELP_FUSION_API_KEY>` with your actual Yelp Fusion API key.
+*   If your MCP client has trouble invoking docker from the system PATH, you might need to provide the full path to its binary (e.g., run which docker).

--- a/src/yelp_agent/main.py
+++ b/src/yelp_agent/main.py
@@ -3,6 +3,7 @@ Main entry point for the Fusion AI MCP server.
 Provides the Yelp business agent tool for conversational business queries
 and recommendations.
 """
+import argparse
 from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -81,9 +82,40 @@ def main():
     Main function to start the Fusion AI MCP server.
     Initializes the MCP server and registers the Yelp interaction tool.
     """
-    logger.info("Starting Fusion AI MCP server")
-    # Initialize the MCP server
-    mcp.run(transport="stdio")
+    parser = argparse.ArgumentParser(description="Yelp MCP Server")
+    parser.add_argument(
+        "--transport",
+        type=str,
+        choices=["stdio", "streamable-http", "sse"],
+        default="stdio",
+        help="The transport type to use for the MCP server.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="The host to bind to for http/sse transports.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="The port to bind to for http/sse transports.",
+    )
+    args = parser.parse_args()
+
+    logger.info(f"Starting Yelp MCP server with {args.transport} transport")
+
+    if args.transport == "streamable-http":
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        mcp.run(transport="streamable-http")
+    elif args.transport == "sse":
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        mcp.run(transport="sse")
+    else:
+        mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 📌 Description

This pull request enhances the Yelp MCP server by introducing command-line arguments for configuration. This allows the server to be run with different transport protocols and network settings, increasing its flexibility for various use cases.

- **What feature, fix, or update does this PR address?**
  - It adds support for `stdio`, `streamable-http`, and `sse` transport protocols.
  - It introduces `--host` and `--port` arguments for network configuration.
- **Why is this change needed?**
  - To provide more flexible deployment options for the server beyond the default `stdio` transport, enabling network-based communication.

---

## ✅ Checklist

Please check all that apply:

- [x] I have tested the changes locally
- [x] I have followed the coding style of the project
- [x] I have updated documentation/comments (if needed)

---

## 📝 Additional Notes (Optional)

The `README.md` has been updated to document the new command-line arguments and provide clear instructions on how to use them.

<img width="1500" height="1286" alt="image" src="https://github.com/user-attachments/assets/cda96d3c-a31f-4652-8928-138b48946392" />
